### PR TITLE
chore: bump go version and update install script

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,10 @@
 module github.com/latitudesh/agent
 
-go 1.22
+go 1.23
 
 require (
-	gopkg.in/yaml.v3 v3.0.1
 	github.com/sirupsen/logrus v1.9.3
+	gopkg.in/yaml.v3 v3.0.1
 )
+
+require golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/install.sh
+++ b/install.sh
@@ -85,7 +85,7 @@ mkdir -p /etc/lsh-agent
 
 # Install Go if not present
 if ! command -v go &>/dev/null; then
-  GO_VERSION="1.22.0"
+  GO_VERSION="1.23.0"
   GO_PACKAGE="go${GO_VERSION}.linux-amd64.tar.gz"
 
   echo "Installing Go..."
@@ -108,7 +108,7 @@ fi
 echo "Building Latitude.sh Agent from source..."
 cd /tmp
 rm -rf agent
-git clone -b feat/go https://github.com/latitudesh/agent.git
+git clone https://github.com/latitudesh/agent.git
 cd agent
 
 # Remove problematic SDK dependency temporarily


### PR DESCRIPTION
## What does this PR do?

Bumps Go version to v1.23 and update dependencies.

## How should this be manually tested?

1. Run the `install.sh` with parameters:
```sh
sudo ./install.sh -firewall fw_... -project proj_...
```

<img width="1113" height="261" alt="image" src="https://github.com/user-attachments/assets/9c5e2c5d-82e0-4ea8-a935-418802563613" />

Check Go version:

```sh
go version
```

You should see:
```sh
go version go1.23.0 linux/amd64
```

Version 1.23 is installed and the agent builds successfully.

2. Verify firewall rules locally
```sh
sudo ufw status
```

3. Check with [dashboard](https://www.latitude.sh/dashboard/networking/firewall)

Go to the Network Firewall page and open the selected firewall.

<img width="1131" height="299" alt="image" src="https://github.com/user-attachments/assets/e13dd700-a3c3-4092-a29f-2ad4bd1d41eb" />


The rules should be identical.