### PR TITLE
Fixes compilation errors caused by runtime redeclaration bug in Go 1.23.0

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -85,7 +85,7 @@ mkdir -p /etc/lsh-agent
 
 # Install Go if not present
 if ! command -v go &>/dev/null; then
-  GO_VERSION="1.23.0"
+  GO_VERSION="1.23.4"
   GO_PACKAGE="go${GO_VERSION}.linux-amd64.tar.gz"
 
   echo "Installing Go..."


### PR DESCRIPTION
## What does this PR do?

Fixes Go installation by updating from v1.23.0 to v1.23.4 to resolve compilation errors.

## Problem

Customers were experiencing build failures during agent installation with errors like:

```sh
/usr/local/go/src/runtime/mbitmap_noallocheaders.go:53:2: mallocHeaderSize redeclared in this block
```

This is a known bug in Go 1.23.0 that was fixed in later patch releases.

## How should this be manually tested?

1. Run the `install.sh` with parameters:
```sh
curl -s https://raw.githubusercontent.com/latitudesh/agent/refs/heads/fix/go-version-1.23.4/install.sh |
sudo bash -s -- -firewall fw_... -project proj_...
```

2. Check Go version:
```sh
go version
```

You should see: `go version go1.23.4 linux/amd64`

3. Verify the agent binary was created successfully:

```sh
lsh-agent --version
```

4. Verify firewall rules locally:

```sh
sudo ufw status
```

5. Check in https://www.latitude.sh/dashboard/networking/firewall

The rules should be identical.