### PR TITLE
fix(firewall): canonicalize diff key to stop UFW rule oscillation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Function to display usage
 usage() {
@@ -67,6 +68,12 @@ for pkg in curl ufw jq git; do
         install_package $pkg || exit 1
     fi
 done
+
+# Install C build environment (required by Go's cgo for the net package)
+if ! dpkg -s build-essential &> /dev/null; then
+    echo "Installing build-essential..."
+    install_package build-essential || exit 1
+fi
 
 # Enable UFW if it's not active
 if ! ufw status | grep -q "Status: active"; then

--- a/internal/collectors/firewall.go
+++ b/internal/collectors/firewall.go
@@ -20,17 +20,23 @@ type FirewallRule struct {
 	Port     string `json:"port"`
 }
 
-// String returns a normalized string representation of the rule
+// String returns a normalized string representation of the rule.
+// Normalization keeps the diff key stable across the API (which keeps
+// /32 and /128 host suffixes and may use uppercase protocol) and ufw
+// status output (which strips /32 and /128 and emits lowercase protocol).
 func (r FirewallRule) String() string {
-	from := r.From
+	from := strings.TrimSpace(r.From)
 	if from == "" {
 		from = "any"
+	} else {
+		from = strings.TrimSuffix(from, "/32")
+		from = strings.TrimSuffix(from, "/128")
 	}
-	protocol := r.Protocol
+	protocol := strings.ToLower(strings.TrimSpace(r.Protocol))
 	if protocol == "" {
 		protocol = "any"
 	}
-	port := r.Port
+	port := strings.TrimSpace(r.Port)
 	if port == "" {
 		port = "any"
 	}

--- a/internal/collectors/firewall_test.go
+++ b/internal/collectors/firewall_test.go
@@ -1,0 +1,114 @@
+package collectors
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestFirewallRuleString(t *testing.T) {
+	cases := []struct {
+		name string
+		rule FirewallRule
+		want string
+	}{
+		{
+			name: "strips /32 from IPv4 host",
+			rule: FirewallRule{From: "8.8.8.8/32", Protocol: "tcp", Port: "8081"},
+			want: "From: 8.8.8.8, Protocol: tcp, Port: 8081",
+		},
+		{
+			name: "strips /128 from IPv6 host",
+			rule: FirewallRule{From: "2001:db8::1/128", Protocol: "tcp", Port: "443"},
+			want: "From: 2001:db8::1, Protocol: tcp, Port: 443",
+		},
+		{
+			name: "preserves real IPv4 CIDR",
+			rule: FirewallRule{From: "10.20.0.0/24", Protocol: "tcp", Port: "8080"},
+			want: "From: 10.20.0.0/24, Protocol: tcp, Port: 8080",
+		},
+		{
+			name: "preserves bare IPv4 host",
+			rule: FirewallRule{From: "1.1.1.1", Protocol: "tcp", Port: "8080"},
+			want: "From: 1.1.1.1, Protocol: tcp, Port: 8080",
+		},
+		{
+			name: "lowercases uppercase protocol",
+			rule: FirewallRule{From: "1.1.1.1", Protocol: "TCP", Port: "8080"},
+			want: "From: 1.1.1.1, Protocol: tcp, Port: 8080",
+		},
+		{
+			name: "empty fields default to any",
+			rule: FirewallRule{},
+			want: "From: any, Protocol: any, Port: any",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.rule.String()
+			if got != tc.want {
+				t.Errorf("String() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSyncDiff_StableForCIDRHostRules(t *testing.T) {
+	fc := NewFirewallCollector("ufw", false, logrus.New())
+
+	apiRules := []FirewallRule{
+		{From: "8.8.8.8/32", Protocol: "TCP", Port: "8081"},
+		{From: "1.1.1.1", Protocol: "TCP", Port: "8080"},
+		{From: "10.20.0.0/24", Protocol: "TCP", Port: "8080"},
+	}
+
+	ufwOutput := `Status: active
+
+To                         Action      From
+--                         ------      ----
+8081/tcp                   ALLOW       8.8.8.8
+8080/tcp                   ALLOW       1.1.1.1
+8080/tcp                   ALLOW       10.20.0.0/24
+`
+
+	currentRules, err := fc.parseUFWRules(ufwOutput)
+	if err != nil {
+		t.Fatalf("parseUFWRules: %v", err)
+	}
+
+	apiSet := fc.rulesToStringSet(apiRules)
+	currentSet := fc.rulesToStringSet(currentRules)
+	toAdd := fc.findRulesToAdd(currentSet, apiSet, apiRules)
+	toRemove := fc.findRulesToRemove(currentSet, apiSet, currentRules)
+
+	if len(toAdd) != 0 {
+		t.Errorf("expected no rules to add, got %d: %+v", len(toAdd), toAdd)
+	}
+	if len(toRemove) != 0 {
+		t.Errorf("expected no rules to remove, got %d: %+v", len(toRemove), toRemove)
+	}
+}
+
+func TestSyncDiff_StableWithCaseSensitiveProtocol(t *testing.T) {
+	fc := NewFirewallCollector("ufw", true, logrus.New())
+
+	apiRules := []FirewallRule{
+		{From: "1.1.1.1", Protocol: "TCP", Port: "8080"},
+	}
+	ufwOutput := "Status: active\n\nTo                         Action      From\n--                         ------      ----\n8080/tcp                   ALLOW       1.1.1.1\n"
+
+	currentRules, err := fc.parseUFWRules(ufwOutput)
+	if err != nil {
+		t.Fatalf("parseUFWRules: %v", err)
+	}
+
+	apiSet := fc.rulesToStringSet(apiRules)
+	currentSet := fc.rulesToStringSet(currentRules)
+	toAdd := fc.findRulesToAdd(currentSet, apiSet, apiRules)
+	toRemove := fc.findRulesToRemove(currentSet, apiSet, currentRules)
+
+	if len(toAdd) != 0 || len(toRemove) != 0 {
+		t.Errorf("expected stable diff with case-sensitive mode, got toAdd=%v toRemove=%v", toAdd, toRemove)
+	}
+}

--- a/internal/collectors/firewall_test.go
+++ b/internal/collectors/firewall_test.go
@@ -90,7 +90,7 @@ To                         Action      From
 	}
 }
 
-func TestSyncDiff_StableWithCaseSensitiveProtocol(t *testing.T) {
+func TestSyncDiff_NoCycleFromMismatchedProtocolCase(t *testing.T) {
 	fc := NewFirewallCollector("ufw", true, logrus.New())
 
 	apiRules := []FirewallRule{


### PR DESCRIPTION
## Summary

Two related fixes that together restore correct firewall sync for affected customers.

### 1. Diff-key canonicalization (`internal/collectors/firewall.go`)

The agent's diff key (`FirewallRule.String()`) was built from raw API and parsed-UFW values that differ in two places:

- API keeps `/32` (and `/128`) host suffixes; `ufw status` strips them on display.
- API protocol is uppercase (`TCP`); `ufw status` emits lowercase (`tcp`).

When these mismatched, every collection cycle classified the same logical rule as both `toAdd` (API form) and `toRemove` (UFW form) and toggled the rule on each 30s tick.

Fix: in `String()`, strip `/32` and `/128`, lowercase protocol, trim whitespace. The `ufw allow` / `ufw delete` commands keep the raw `from` value — ufw accepts both forms — so on-the-wire behavior is unchanged.

### 2. `install.sh` hardening

Two fragility points on a fresh Ubuntu 24.04 image:

- `build-essential`/`libc6-dev` is not in the apt deps, so `go build` failed with `_cgo_export.c:3: fatal error: stdlib.h: No such file or directory`.
- Without `set -e`, the script kept going after the build failed and still registered a systemd unit pointing at a non-existent `/usr/local/bin/lsh-agent`, leaving the box in a `Restart=always` loop with no clear failure signal.

Fix: add `set -e` at the top and install `build-essential` explicitly.

## Origin

Affected customer servers.

## Tests

This is the first test file in `internal/collectors/`:

- `TestSyncDiff_StableForCIDRHostRules` — regression: feeds an API rule with `from: "8.8.8.8/32"` and synthetic `ufw status` output containing `8.8.8.8`, asserts `toAdd` and `toRemove` are both empty.
- `TestSyncDiff_StableWithCaseSensitiveProtocol` — guards the latent protocol-case bug if anyone flips `case_sensitive: true`.
- `TestFirewallRuleString` — table-driven coverage of the `String()` normalization rules.

## Out of scope (flagged for follow-up PRs)

- `to` field is silently dropped — `addUFWRule` always uses `to any`.
- UFW status parse regex `[0-9]+/[a-z]+` doesn't match port ranges (`8000:9000/tcp`), so range rules are silently re-added every cycle (UFW dedups so no flapping, but noisy journal).
- IPv6 rules are filtered out of the parser entirely.
- `sed -i '/latitudesh-go-sdk/d' go.mod` in `install.sh` is dead code (SDK was removed in `ee106ea`).
- `EXTRA_PARAMETERS` parsed but never used.

## Test plan

On a fresh Ubuntu 24.04 server with a Latitude firewall assigned that contains a `<host>/32` rule:

1. `curl -s https://raw.githubusercontent.com/latitudesh/agent/refs/heads/fix/firewall-rule-cycling/install.sh | sudo bash -s -- -firewall <fw_id> -project <proj_id>`
2. `sudo systemctl is-active lsh-agent` → `active`
3. Wait ≥ 60s, then `sudo journalctl -u lsh-agent --since "2 minutes ago" | grep -E "Added rule|Removed rule|No changes made"`. Expect `Added rule` only on the first cycle post-restart, then `No changes made, skipping UFW reload` repeating.
4. Sample `sudo ufw status` four times 30s apart — the `<host>/32` row stays present in all four samples.

Verified end-to-end against `api.latitude.sh` on a fresh Ubuntu 24.04 server (`para-agent-firewall-test`, 189.1.171.85) with a firewall rule `8.8.8.8/32 → ANY:tcp:8081`. Pre-fix: `8081` row flipped between present and absent every 30s. Post-fix: present across 5+ steady-state cycles in the journal and 4/4 stability samples.